### PR TITLE
fixes and corrections to flux element indices, def_dt 

### DIFF
--- a/src/fluids/cosmicrays/initcosmicrays.F90
+++ b/src/fluids/cosmicrays/initcosmicrays.F90
@@ -305,7 +305,7 @@ contains
       implicit none
 
       type(var_numbers), intent(inout) :: flind
-      integer(kind=4)                  :: icr, jnb
+      integer(kind=4)                  :: icr
 
       flind%crn%beg = flind%all + I_ONE
       flind%crs%beg = flind%crn%beg
@@ -342,16 +342,14 @@ contains
       flind%crspc%ebeg = flind%crspc%nend + I_ONE
       flind%crspc%eend = flind%crspc%nend + ncrb * nspc
 
-      do icr = 1, ncrb
+      do icr = 1, ncr2b
          iarr_crspc_n(icr) = flind%crspc%nbeg - I_ONE + icr
          iarr_crspc_e(icr) = flind%crspc%ebeg - I_ONE + icr
       enddo
 
       do icr = 1, nspc        !< Arrange iterable indexes for each spectral species separately; first indexes for n, then e.
-         do jnb = 1, ncrb
-            iarr_crspc2_n(icr, jnb) = flind%crn%end + I_ONE + (icr - I_ONE) * ncrb + jnb
-            iarr_crspc2_e(icr, jnb) = flind%crn%end + I_ONE + nspc * ncrb + (icr - I_ONE) * ncrb + jnb
-         enddo
+         iarr_crspc2_n(icr, :) = iarr_crspc_n(I_ONE + (icr - I_ONE) * ncrb: ncrb + (icr - I_ONE) * ncrb)
+         iarr_crspc2_e(icr, :) = iarr_crspc_e(I_ONE + (icr - I_ONE) * ncrb: ncrb + (icr - I_ONE) * ncrb)
       enddo
 #endif /* CRESP */
 

--- a/src/fluids/cosmicrays/initcrspectrum.F90
+++ b/src/fluids/cosmicrays/initcrspectrum.F90
@@ -592,14 +592,14 @@ contains
       write (msg,"(A,*(E14.5))") "[initcrspectrum:init_cresp] K_cresp_perp = ",  K_cresp_perp(1:ncrb)  ; if (master) call printinfo(msg)
 #endif /* VERBOSE */
 
-      def_dtadiab = cfl_cre * half * three * logten * w
-      def_dtsynch = cfl_cre * half * w
+      def_dtadiab(:) = cfl_cre(:) * half * three * logten * w
+      def_dtsynch(:) = cfl_cre(:) * half * w
 
       u_b_max = maxval(fsynchr(:)) * emag(b_max_db, 0., 0.)   !< initializes factor for comparing u_b with u_b_max
 
       write (msg, "(A,F10.4,A,ES12.5)") "[initcrspectrum:init_cresp] Maximal B_tot =",b_max_db, "mGs, u_b_max = ", u_b_max
       if (master)  call warn(msg)
-      write (msg, "(A,ES12.5,A,ES15.8,A,ES15.8)") "[initcrspectrum:init_cresp] dt_synch(p_max_fix = ",p_max_fix,", u_b_max = ",u_b_max,") = ", def_dtsynch / (p_max_fix* u_b_max)   ! TODO FIXME - I am not working properly for multiple spectral CR species!
+      write (msg, "(A,ES12.5,A,ES15.8,A,ES15.8)") "[initcrspectrum:init_cresp] Minimal dt_synch(p_max_fix = ",p_max_fix,", u_b_max = ",u_b_max,") = ", minval(def_dtsynch) / (p_max_fix* u_b_max)
       if (master)  call warn(msg)
 
       if (cresp_substep) then
@@ -831,6 +831,8 @@ contains
       call my_allocate(K_cre_pow, ma1d)
       call my_allocate(p_diff, ma1d)
       call my_allocate(fsynchr, ma1d)
+      call my_allocate(def_dtadiab, ma1d)
+      call my_allocate(def_dtsynch, ma1d)
 
       ma2d = [nsp, nb * 2]
       call my_allocate(K_cresp_paral, ma2d)


### PR DESCRIPTION
Properly allocates def_dt{synch,adiab} and picks the relevant warning for def_dtsynch, uses correct index list for species-iterated iarr_crsp2_{n,e} lists.