### PR TITLE
Fix to the way of passing n,e to timestep-computing subroutine 

### DIFF
--- a/src/fluids/cosmicrays/cresp_grid.F90
+++ b/src/fluids/cosmicrays/cresp_grid.F90
@@ -170,7 +170,7 @@ contains
                   if (adiab_active) sptab%ud = cg%q(divv_i)%point([i,j,k]) * onet
 
                   if (cresp_substep) then !< prepare substep timestep for each cell
-                     call cresp_timestep_cell(sptab, dt_cresp, inactive_cell)
+                     call cresp_timestep_cell(cresp%n, cresp%e, sptab, dt_cresp, inactive_cell)
                      call prepare_substep(dt_doubled, dt_cresp, dt_crs_sstep, nssteps)
                      dt_cresp = dt_crs_sstep    !< 2 * dt is equal to nssteps * dt_crs_sstep
                      nssteps_max = max(n_substeps_max, nssteps)

--- a/src/fluids/cosmicrays/timestep_cresp.F90
+++ b/src/fluids/cosmicrays/timestep_cresp.F90
@@ -190,9 +190,10 @@ contains
 !----------------------------------------------------------------------------------------------------
 !! \brief This subroutine returns timestep for cell at (i,j,k) position, with already prepared u_b and u_d values.
 
-   subroutine cresp_timestep_cell(p_loss_terms, cresp_dt_cell, i_spc, empty_cell)
+   subroutine cresp_timestep_cell(cresp_n, cresp_e, p_loss_terms, cresp_dt_cell, i_spc, empty_cell)
 
-      use initcrspectrum,     only: adiab_active, cresp, synch_active, spec_mod_trms
+      use initcrspectrum,     only: adiab_active, synch_active, spec_mod_trms
+      use initcosmicrays,     only: ncrb
       use cresp_crspectrum,   only: cresp_find_prepare_spectrum
       use constants,          only: big
 
@@ -204,6 +205,7 @@ contains
       integer(kind=4)                 :: i_up_cell
       integer(kind=4),    intent(in)  :: i_spc
       real                            :: dt_cre_adiab_cell, dt_cre_synch_cell
+      real, dimension(1:ncrb), intent(inout) :: cresp_n, cresp_e
 
       dt_cre_adiab = big
       dt_cre_synch = big
@@ -211,7 +213,7 @@ contains
 
       empty_cell = .false.
 
-      call cresp_find_prepare_spectrum(cresp%n, cresp%e, empty_cell, i_up_cell) ! needed for synchrotron timestep
+      call cresp_find_prepare_spectrum(cresp_n, cresp_e, empty_cell, i_up_cell) ! needed for synchrotron timestep
 
       if (.not. empty_cell) then
          if (synch_active(i_spc)) dt_cre_synch_cell = cresp_dt_synch_species(p_loss_terms%ub, i_up_cell, i_spc)


### PR DESCRIPTION
Drops passing arguments via external module.