### PR TITLE
Change cr names

### DIFF
--- a/bin/gdf_distance
+++ b/bin/gdf_distance
@@ -166,6 +166,16 @@ def compare_dlists(h5f1, h5f2):
             f.remove("particles")
 
     fc = list(set(f1) & set(f2))
+    if ("cree01" in f1) == ("cr_e-e01" in f2):
+        f1c = []
+        f2c = []
+        cre_ = re.compile("^cre[en][0-9][0-9]").search
+        for f in f1:
+            f1c.append(f.replace("cre", "cr_e-") if bool(cre_(f)) else f)
+        for f in f2:
+            f2c.append(f.replace("cre", "cr_e-") if bool(cre_(f)) else f)
+        fc = list(set(f1c) & set(f2c))
+        print("Comparing CR components with old and new names (like 'cree01' translated to 'cr_e-e01')")
     if (len(fc) != len(f1)):
         print("Fields unique for `", h5f1.filename, "': ", list(set(f1) ^ set(fc)))
     if (len(fc) != len(f2)):
@@ -270,7 +280,13 @@ def collect_dataset(h5f, dset_name, level):
             n_b = [int(ngb[0]), int(ngb[1]), int(ngb[2])]
             ce = n_b + off
             for i in range(len(dset_name)):
-                dset[i, off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]] = h5g[dset_name[i]][:, :, :].swapaxes(0, 2)
+                if dset_name[i] in h5g:
+                    ds = dset_name[i]
+                elif dset_name[i].replace("cr_e-", "cre") in h5g:
+                    ds = dset_name[i].replace("cr_e-", "cre")
+                else:
+                    raise KeyError
+                dset[i, off[0]:ce[0], off[1]:ce[1], off[2]:ce[2]] = h5g[ds][:, :, :].swapaxes(0, 2)
 
     return dset, nd, levelmet
 

--- a/jenkins/gold_configs/mcrtest_CRESP.config
+++ b/jenkins/gold_configs/mcrtest_CRESP.config
@@ -1,8 +1,7 @@
 # sha1 of the gold commit
 # Note: update only when absolutely necessary
-GOLD_COMMIT=09f37deda7a1d2e8d590e60b801324f61c905c3e
+GOLD_COMMIT=6d0b571fef22a8a87bb3ee12a53d771fc63e6d2c
 
-# 09f37deda7a1d2e8d590e60b801324f61c905c3e - rename cresp variables : cree, cren to cr_e-e, cr_e-e
 # 6d0b571fef22a8a87bb3ee12a53d771fc63e6d2c – new gold_test.sh script and major change in configuration on Jenkins
 # 74978ace728553380b355791e33d8e7c25586869 – changed arr_dim to speed up this gold test
 # 9a94fca07452ba7f5ba8bc8d55e6a33ee722abb5 - [initcosmicrays] gamma_crn changed to general gamma_cr for non-spectral CR components

--- a/src/IO/dataio_pub.F90
+++ b/src/IO/dataio_pub.F90
@@ -41,10 +41,10 @@ module dataio_pub
    private :: cbuff_len, domlen, idlen, cwdlen ! QA_WARN prevent re-exporting
    !mpisetup uses: ansi_white and ansi_black
 
-   real, parameter             :: piernik_hdf5_version = 1.18    !< output version
+   real, parameter             :: piernik_hdf5_version = 1.19    !< output version
 
    ! v2 specific
-   real, parameter             :: piernik_hdf5_version2 = 2.02   !< output version for multi-file, multi-domain I/O
+   real, parameter             :: piernik_hdf5_version2 = 2.03   !< output version for multi-file, multi-domain I/O
    logical                     :: use_v2_io                      !< prefer the new I/O format
    logical                     :: gdf_strict                     !< adhere more strictly to GDF standard
    integer(kind=4)             :: nproc_io                       !< how many processes do the I/O (v2 only)


### PR DESCRIPTION
The `gdf_distance` can now compare new and old files so no need to update SHA1 for CRESP gold test.